### PR TITLE
idris-syntax.el faces covered

### DIFF
--- a/punpun-common.el
+++ b/punpun-common.el
@@ -182,6 +182,12 @@
    (ido-only-match :weight bold)
    (ido-subdir :inherit font-lock-string-face)
 
+   ;; idris-syntax.el
+   (idris-semantic-function-face :inherit font-lock-function-name-face)
+   (idris-semantic-data-face :inherit font-lock-constant-face)
+   (idris-semantic-type-face :inherit font-lock-type-face)
+   (idris-semantic-bound-face :inherit font-lock-variable-name-face)
+
    ;; isearch.el
    (isearch :background base2)
    (isearch-fail :inherit error)


### PR DESCRIPTION
This pull request is a fraction of changes I've made to the local version. I'll likely brush my local stuff in the next couple of days and open a few more of those.

This PR affects highlighting after typecheck in `idris-mode` (the one provided by font-lock functions as normal; the one from `idris-syntax.el` is affected).